### PR TITLE
feat: configure session cookie key

### DIFF
--- a/.agents/skills/create-pr-build-deploy-staging/SKILL.md
+++ b/.agents/skills/create-pr-build-deploy-staging/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: create-pr-build-deploy-staging
+description: Use when working in this repository and the user wants the current changes pushed as a pull request, then wants GitHub Actions Docker image build to finish successfully before deploying to the Staging environment.
+---
+
+# Create PR, Build, and Deploy Staging
+
+## Overview
+
+This skill handles the repo-specific release flow for `brando-node`:
+create or update a feature branch, push it, create a PR, manually trigger Docker image CI, wait for it to finish, then deploy to `Staging`.
+
+The goal is to give the user one clean, end-to-end operation with explicit links and final status.
+
+## When to Use
+
+Use this skill only in this repository, where these workflows already exist:
+
+- `.github/workflows/docker-publish.yml`
+- `.github/workflows/deploy.yml`
+
+Do not use this skill if the user only wants local git help, only wants a PR, or wants deployment without waiting for the image build.
+
+## Required Checks
+
+Before changing git or GitHub state:
+
+1. Confirm `gh auth status` succeeds.
+2. Inspect `git status --short --branch`.
+3. Run the most relevant verification that already exists for the current change.
+4. If verification fails, stop and report the failure before creating a branch or PR.
+
+Prefer lightweight repo-appropriate verification over inventing a full new test plan.
+
+## Workflow
+
+### 1. Prepare branch
+
+- If already on a suitable feature branch, keep using it.
+- If on `main` or another unsuitable branch, create a feature branch with a concise name.
+- Never discard unrelated user changes.
+
+### 2. Commit and push
+
+- Review the diff for the files relevant to the request.
+- Stage only the intended files.
+- Create a focused commit message.
+- Push with `git push -u origin <branch>`.
+
+### 3. Create PR
+
+- Create the PR with `gh pr create`.
+- Base branch should normally be `main`.
+- PR body should include:
+  - `## Summary`
+  - `## Test Plan`
+- Capture and report the PR URL.
+
+### 4. Manually trigger Docker image build
+
+- After the PR is created, manually trigger the Docker workflow for the branch:
+
+```bash
+gh workflow run docker-publish.yml --ref <branch>
+```
+
+- Find the workflow-dispatch run for the current branch with `gh run list --workflow "Docker Image CI" --branch <branch>`.
+- Wait for that run with `gh run watch <run-id> --exit-status`.
+- If the build fails, stop and report the run URL instead of deploying.
+
+### 5. Deploy to staging
+
+- Trigger deploy with:
+
+```bash
+gh workflow run deploy.yml -f environment=Staging
+```
+
+- Find the new `Deploy` run and wait for it to complete.
+- If it fails, report the deploy run URL and failure status clearly.
+
+## Final Response
+
+Always report:
+
+- branch name
+- PR URL
+- Docker Image CI run URL and final status
+- Deploy run URL and final status
+
+If anything failed, say exactly which stage failed and do not imply deployment succeeded.
+
+## Common Mistakes
+
+- Watching the wrong workflow run because another branch finished more recently
+- Assuming a branch push is the build trigger for this skill
+- Deploying before `Docker Image CI` has completed successfully
+- Creating a PR without a clear `Summary` and `Test Plan`
+- Reporting success without including the GitHub Actions links

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+DB_HOST=127.0.0.1
+DB_USER=brando
+DB_PASS=replace-with-real-password
+DB_NAME=brando
+
+SECRET_ID=replace-with-s3-access-key
+SECRET_KEY=replace-with-s3-secret-key
+
+SSO_GRPC=127.0.0.1:2999
+SESSION_COOKIE_KEY=delbertbeta-s-sso
+
+IMAGES_BUCKET_NAME=brando-static
+BUCKET_ENDPOINT=https://example.r2.cloudflarestorage.com
+BUCKET_REGION=auto
+CDN_PREFIX=https://static.example.com/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ cd /opt/brando-node
 
 ## `.env` 配置
 
-在目标机器上创建 `/opt/brando-node/.env`：
+可以先用仓库里的示例文件生成：
+
+```bash
+cp .env.example /opt/brando-node/.env
+```
+
+再按实际环境修改 `/opt/brando-node/.env`：
 
 ```dotenv
 DB_HOST=127.0.0.1
@@ -48,6 +54,7 @@ SECRET_ID=replace-with-s3-access-key
 SECRET_KEY=replace-with-s3-secret-key
 
 SSO_GRPC=127.0.0.1:2999
+SESSION_COOKIE_KEY=delbertbeta-s-sso
 
 IMAGES_BUCKET_NAME=brando-static
 BUCKET_ENDPOINT=https://example.r2.cloudflarestorage.com
@@ -64,6 +71,7 @@ CDN_PREFIX=https://static.example.com/
 - `SECRET_ID`: 对象存储 Access Key ID
 - `SECRET_KEY`: 对象存储 Secret Access Key
 - `SSO_GRPC`: SSO gRPC 服务地址，格式通常是 `host:port`
+- `SESSION_COOKIE_KEY`: 登录态 cookie 名称；不填时默认读取 `delbertbeta-s-sso`
 - `IMAGES_BUCKET_NAME`: 图片上传目标 bucket 名
 - `BUCKET_ENDPOINT`: S3 兼容存储 endpoint，例如 Cloudflare R2 endpoint
 - `BUCKET_REGION`: 对象存储 region；如果是 R2，通常填 `auto`

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -3,13 +3,14 @@ import { BrandoError, ErrorRes } from '$typings/errors';
 import { Response } from '$typings/response';
 import { RequestHandler } from 'express';
 import { promisedGetUserIdByCookie } from 'src/rpc';
+import { getSessionCookieKey } from './session-cookie';
 
 export const auth: RequestHandler<{}, Response<ErrorRes>> = async (
   req,
   _res,
   next
 ) => {
-  const loginCookie = req.cookies['delbertbeta-s-sso'];
+  const loginCookie = req.cookies[getSessionCookieKey()];
 
   let userId: number | null = null;
   try {

--- a/src/middlewares/session-cookie.ts
+++ b/src/middlewares/session-cookie.ts
@@ -1,0 +1,5 @@
+const DEFAULT_SESSION_COOKIE_KEY = 'delbertbeta-s-sso';
+
+export const getSessionCookieKey = (): string =>
+  process.env.SESSION_COOKIE_KEY || DEFAULT_SESSION_COOKIE_KEY;
+

--- a/tests/session-cookie.test.ts
+++ b/tests/session-cookie.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getSessionCookieKey } from '../src/middlewares/session-cookie';
+
+test('getSessionCookieKey prefers SESSION_COOKIE_KEY from environment', () => {
+  const previous = process.env.SESSION_COOKIE_KEY;
+  process.env.SESSION_COOKIE_KEY = 'custom-session-cookie';
+
+  try {
+    assert.equal(getSessionCookieKey(), 'custom-session-cookie');
+  } finally {
+    if (previous === undefined) {
+      delete process.env.SESSION_COOKIE_KEY;
+    } else {
+      process.env.SESSION_COOKIE_KEY = previous;
+    }
+  }
+});
+
+test('getSessionCookieKey falls back to the default cookie name', () => {
+  const previous = process.env.SESSION_COOKIE_KEY;
+  delete process.env.SESSION_COOKIE_KEY;
+
+  try {
+    assert.equal(getSessionCookieKey(), 'delbertbeta-s-sso');
+  } finally {
+    if (previous === undefined) {
+      delete process.env.SESSION_COOKIE_KEY;
+    } else {
+      process.env.SESSION_COOKIE_KEY = previous;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- read the session cookie name from `SESSION_COOKIE_KEY`
- fall back to `delbertbeta-s-sso` when the environment variable is unset
- document the setting in `README.md` and add `.env.example`
- add a repo-local skill for creating a PR, manually triggering Docker image CI, and deploying to `Staging`

## Test Plan
- compile and run `tests/session-cookie.test.ts`
- run `pnpm run build`
