### PR TITLE
Add login state diagnostics for user endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "brando",
   "version": "0.0.0",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "start": "pnpm run build && node --enable-source-maps ./dist/app.js",
     "build": "rimraf ./dist && node config/build.js",

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,29 +1,95 @@
 import { ErrorType } from '$consts/errors';
 import { BrandoError, ErrorRes } from '$typings/errors';
 import { Response } from '$typings/response';
+import { brandoLogger } from '$logger';
 import { RequestHandler } from 'express';
 import { promisedGetUserIdByCookie } from 'src/rpc';
 import { getSessionCookieKey } from './session-cookie';
+
+const getErrorInfo = (e: unknown) => {
+  if (e instanceof Error) {
+    return {
+      name: e.name,
+      message: e.message,
+      stack: e.stack,
+    };
+  }
+
+  return e;
+};
 
 export const auth: RequestHandler<{}, Response<ErrorRes>> = async (
   req,
   _res,
   next
 ) => {
-  const loginCookie = req.cookies[getSessionCookieKey()];
+  const sessionCookieKey = getSessionCookieKey();
+  const loginCookie = req.cookies[sessionCookieKey];
+  const authContext = {
+    method: req.method,
+    originalUrl: req.originalUrl,
+    path: req.path,
+    sessionCookieKey,
+    cookieKeys: Object.keys(req.cookies || {}),
+    hasLoginCookie: Boolean(loginCookie),
+    loginCookieLength: loginCookie?.length || 0,
+    origin: req.get('origin'),
+    referer: req.get('referer'),
+    userAgent: req.get('user-agent'),
+    forwardedFor: req.get('x-forwarded-for'),
+    ip: req.ip,
+  };
+
+  brandoLogger.info(`[auth] checking login state ${JSON.stringify(authContext)}`);
 
   let userId: number | null = null;
   try {
     if (loginCookie) {
-      userId = (
-        await promisedGetUserIdByCookie({
-          cookie: loginCookie,
-        })
-      ).userId;
+      const startedAt = Date.now();
+      const userIdRes = await promisedGetUserIdByCookie({
+        cookie: loginCookie,
+      });
+      userId = userIdRes.userId;
+      brandoLogger.info(
+        `[auth] sso getUserIdByCookie finished ${JSON.stringify({
+          method: req.method,
+          originalUrl: req.originalUrl,
+          userId,
+          durationMs: Date.now() - startedAt,
+        })}`
+      );
+    } else {
+      brandoLogger.warn(
+        `[auth] login cookie missing ${JSON.stringify({
+          method: req.method,
+          originalUrl: req.originalUrl,
+          sessionCookieKey,
+          cookieKeys: Object.keys(req.cookies || {}),
+        })}`
+      );
     }
-  } catch (e) {}
+  } catch (e) {
+    brandoLogger.error(
+      `[auth] sso getUserIdByCookie failed ${JSON.stringify({
+        method: req.method,
+        originalUrl: req.originalUrl,
+        sessionCookieKey,
+        hasLoginCookie: Boolean(loginCookie),
+        loginCookieLength: loginCookie?.length || 0,
+        error: getErrorInfo(e),
+      })}`
+    );
+  }
 
   if (userId === null) {
+    brandoLogger.warn(
+      `[auth] rejecting request as not logged in ${JSON.stringify({
+        method: req.method,
+        originalUrl: req.originalUrl,
+        sessionCookieKey,
+        hasLoginCookie: Boolean(loginCookie),
+      })}`
+    );
     next({
       type: ErrorType.NotLogin,
     } as BrandoError);
@@ -31,6 +97,14 @@ export const auth: RequestHandler<{}, Response<ErrorRes>> = async (
   }
 
   req.userId = userId;
+
+  brandoLogger.info(
+    `[auth] login state accepted ${JSON.stringify({
+      method: req.method,
+      originalUrl: req.originalUrl,
+      userId,
+    })}`
+  );
 
   next();
 };

--- a/src/routes/api/v1/user/index.ts
+++ b/src/routes/api/v1/user/index.ts
@@ -4,15 +4,47 @@ import { User } from '$rpc-gen/user';
 import { promisedGetUserByIds } from '$rpc';
 import { ErrorType } from '$consts/errors';
 import { wrapRes } from '$utils';
+import { brandoLogger } from '$logger';
+
+const getErrorInfo = (e: unknown) => {
+  if (e instanceof Error) {
+    return {
+      name: e.name,
+      message: e.message,
+      stack: e.stack,
+    };
+  }
+
+  return e;
+};
 
 export const userRouter = Router({ mergeParams: true });
 userRouter
   .route('/')
   .get<{}, Response<{ user: User }>, {}>(async (req, res, next) => {
     try {
+      brandoLogger.info(
+        `[user] fetching current user ${JSON.stringify({
+          method: req.method,
+          originalUrl: req.originalUrl,
+          userId: req.userId,
+        })}`
+      );
+
+      const startedAt = Date.now();
       const userInfos = await promisedGetUserByIds({
         userId: [req.userId!],
       });
+      brandoLogger.info(
+        `[user] getUser rpc finished ${JSON.stringify({
+          method: req.method,
+          originalUrl: req.originalUrl,
+          userId: req.userId,
+          durationMs: Date.now() - startedAt,
+          responseUserIds: Object.keys(userInfos.users || {}),
+          foundCurrentUser: Boolean(userInfos.users[req.userId!]),
+        })}`
+      );
       if (!userInfos.users[req.userId!]) {
         throw new Error('User not found');
       }
@@ -22,6 +54,14 @@ userRouter
         })
       );
     } catch (e) {
+      brandoLogger.error(
+        `[user] get current user failed ${JSON.stringify({
+          method: req.method,
+          originalUrl: req.originalUrl,
+          userId: req.userId,
+          error: getErrorInfo(e),
+        })}`
+      );
       next({
         type: ErrorType.ServiceInternalError,
         extraInfo: `Get user info failed: ${JSON.stringify(e)}`,


### PR DESCRIPTION
## Summary
- Add structured auth middleware logs around session cookie detection and SSO userId lookup
- Add /user endpoint logs around current-user RPC lookup and failure handling
- Avoid logging raw cookie values while preserving enough context to debug missing login state
- Pin pnpm to 9.15.9 so Docker builds use a Node 20-compatible package manager

## Test Plan
- pnpm build
- CI=true pnpm install --frozen-lockfile
- pnpm exec tsc --noEmit (fails on existing albums route type errors: src/routes/api/v1/albums/index.ts:59,62,72)
- docker build --target build -t brando-node:debug-user-login-state-logs-build . (blocked locally by Docker Hub EOF before project build steps)