### PR TITLE
feat: extract Motion Photo video assets

### DIFF
--- a/src/db/models/image.ts
+++ b/src/db/models/image.ts
@@ -3,6 +3,7 @@ import { sequelize } from '$db/connection';
 import { Photo } from './photo';
 import { ImageModel } from '$typings/images';
 import { generateCDNUrl } from '$utils';
+import { serializeImagePaths } from '$routes/api/v1/images/serializers';
 
 export class Image extends Model<ImageModel> {}
 
@@ -31,6 +32,11 @@ Image.init(
       field: 'object_path',
       allowNull: false,
     },
+    livePhoto: {
+      type: DataTypes.JSON,
+      field: 'live_photo',
+      allowNull: true,
+    },
   },
   {
     sequelize,
@@ -46,15 +52,5 @@ Photo.hasOne(Image, {
 Image.belongsTo(Photo, { as: 'photo' });
 
 export function processImageObj(image: ImageModel): ImageModel {
-  return {
-    ...image,
-    objectPath: generateCDNUrl(image.objectPath),
-    proxied: Object.entries(image.proxied).reduce<ImageModel['proxied']>(
-      (pre, acc) => {
-        pre[acc[0] as keyof ImageModel['proxied']] = generateCDNUrl(acc[1]);
-        return pre;
-      },
-      {}
-    ),
-  };
+  return serializeImagePaths(image, generateCDNUrl);
 }

--- a/src/routes/api/v1/images/consts.ts
+++ b/src/routes/api/v1/images/consts.ts
@@ -5,4 +5,6 @@ export const supportImageExt = new Set([
   'jpeg',
   'png',
   'webp',
+  'heic',
+  'heif',
 ]);

--- a/src/routes/api/v1/images/index.ts
+++ b/src/routes/api/v1/images/index.ts
@@ -16,6 +16,7 @@ import { promisify } from 'util';
 import { Op } from 'sequelize';
 import exifr from 'exifr';
 import fs from 'fs';
+import { readFile } from 'fs/promises';
 import {
   composeWatermark,
   convertExposureTime,
@@ -24,18 +25,19 @@ import {
   convertISO,
   resizeImage,
   resizeImageByShortSide,
+  uploadBuffer,
   uploadImage,
 } from './utils';
-import _imageSize from 'image-size';
 import {
   convertEvString,
   getProcessedImageFilename,
   getProxyLevels,
 } from './formatters';
+import { parseMotionPhotoFromBuffer } from './motion-photo';
+import sharp from 'sharp';
 
 const promisedSha256File = promisify<string, string>(sha256File);
 const unlink = promisify(fs.unlink);
-const getImageSize = promisify(_imageSize);
 
 const imagesRouter = Router({ mergeParams: true });
 
@@ -92,6 +94,11 @@ imagesRouter
 
       const imageId = v4();
       try {
+        const originalBuffer = await readFile(file.path);
+        const motionPhoto = parseMotionPhotoFromBuffer(
+          originalBuffer,
+          fileInfo.ext
+        );
         const metaData = await exifr.parse(file.path);
 
         const exifObj: ImageModel['exif'] = {
@@ -109,7 +116,7 @@ imagesRouter
         };
 
         // 转码
-        const imageSize = await getImageSize(file.path);
+        const imageSize = await sharp(file.path).rotate().metadata();
 
         if (!imageSize || !imageSize.height || !imageSize.width) {
           next({
@@ -187,6 +194,22 @@ imagesRouter
           })
         );
 
+        const livePhoto = motionPhoto
+          ? {
+            videoPath: `live-photos/${imageId}.${motionPhoto.extension}`,
+            mime: motionPhoto.mime,
+            presentationTimestampUs: motionPhoto.presentationTimestampUs,
+          }
+          : undefined;
+
+        if (motionPhoto && livePhoto) {
+          await uploadBuffer(
+            motionPhoto.videoBuffer,
+            livePhoto.videoPath,
+            motionPhoto.mime
+          );
+        }
+
         // 清理 /tmp
         paths.forEach((path) => {
           unlink(path);
@@ -197,6 +220,7 @@ imagesRouter
           objectPath: objectPaths.origin!,
           sha256,
           exif: exifObj,
+          livePhoto,
           proxied: {
             '480p': objectPaths['480p'],
             '720p': objectPaths['720p'],

--- a/src/routes/api/v1/images/motion-photo.ts
+++ b/src/routes/api/v1/images/motion-photo.ts
@@ -1,0 +1,132 @@
+export type MotionPhotoInfo = {
+  videoBuffer: Buffer;
+  mime: 'video/mp4' | 'video/quicktime';
+  extension: 'mp4' | 'mov';
+  presentationTimestampUs?: number;
+};
+
+const getAttr = (source: string, attr: string) => {
+  const pattern = new RegExp(`${attr}="([^"]+)"`);
+  return source.match(pattern)?.[1];
+};
+
+const parsePositiveInt = (value?: string) => {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return undefined;
+  }
+
+  return parsed;
+};
+
+const parseTimestamp = (xmp: string) => {
+  const attrValue = getAttr(xmp, 'GCamera:MicroVideoPresentationTimestampUs');
+  const attrTimestamp = parsePositiveInt(attrValue);
+  if (attrTimestamp !== undefined) {
+    return attrTimestamp;
+  }
+
+  const tagValue = xmp.match(
+    /<GCamera:MotionPhotoPresentationTimestampUs>(\d+)<\/GCamera:MotionPhotoPresentationTimestampUs>/
+  )?.[1];
+  return parsePositiveInt(tagValue);
+};
+
+const parseMime = (value?: string): MotionPhotoInfo['mime'] => {
+  if (value === 'video/quicktime') {
+    return 'video/quicktime';
+  }
+
+  return 'video/mp4';
+};
+
+const parseContainerVideo = (xmp: string) => {
+  const itemMatches = xmp.match(/<(?:Container|GContainer):Item\b[^>]*>/g);
+  if (!itemMatches) {
+    return undefined;
+  }
+
+  for (let i = itemMatches.length - 1; i >= 0; i--) {
+    const item = itemMatches[i];
+    const semantic = getAttr(item, '(?:Item|GContainerItem):Semantic');
+    const mime = getAttr(item, '(?:Item|GContainerItem):Mime');
+    const length = parsePositiveInt(
+      getAttr(item, '(?:Item|GContainerItem):Length')
+    );
+    const padding = Number(
+      getAttr(item, '(?:Item|GContainerItem):Padding') || '0'
+    );
+
+    if (
+      length &&
+      mime?.startsWith('video/') &&
+      (!semantic || /MotionPhoto|MotionPhotoVideo|Video/i.test(semantic))
+    ) {
+      return {
+        length,
+        padding: Number.isFinite(padding) && padding > 0 ? padding : 0,
+        mime: parseMime(mime),
+      };
+    }
+  }
+
+  return undefined;
+};
+
+const extractFromTail = (
+  buffer: Buffer,
+  length: number,
+  padding: number,
+  mime: MotionPhotoInfo['mime'],
+  presentationTimestampUs?: number
+): MotionPhotoInfo | null => {
+  const end = buffer.length - padding;
+  const start = end - length;
+
+  if (start < 0 || end > buffer.length || start >= end) {
+    return null;
+  }
+
+  return {
+    videoBuffer: buffer.subarray(start, end),
+    mime,
+    extension: mime === 'video/quicktime' ? 'mov' : 'mp4',
+    presentationTimestampUs,
+  };
+};
+
+export const parseMotionPhotoFromBuffer = (
+  buffer: Buffer,
+  _fileExt: string
+): MotionPhotoInfo | null => {
+  const xmp = buffer.toString('utf8');
+  const presentationTimestampUs = parseTimestamp(xmp);
+  const containerVideo = parseContainerVideo(xmp);
+
+  if (containerVideo) {
+    return extractFromTail(
+      buffer,
+      containerVideo.length,
+      containerVideo.padding,
+      containerVideo.mime,
+      presentationTimestampUs
+    );
+  }
+
+  const legacyOffset = parsePositiveInt(getAttr(xmp, 'GCamera:MicroVideoOffset'));
+  if (legacyOffset !== undefined) {
+    return extractFromTail(
+      buffer,
+      legacyOffset,
+      0,
+      'video/mp4',
+      presentationTimestampUs
+    );
+  }
+
+  return null;
+};

--- a/src/routes/api/v1/images/serializers.ts
+++ b/src/routes/api/v1/images/serializers.ts
@@ -1,0 +1,22 @@
+import type { ImageModel } from '$typings/images';
+
+export const serializeImagePaths = (
+  image: ImageModel,
+  generateUrl: (path: string) => string
+): ImageModel => ({
+  ...image,
+  objectPath: generateUrl(image.objectPath),
+  proxied: Object.entries(image.proxied || {}).reduce<ImageModel['proxied']>(
+    (pre, acc) => {
+      pre[acc[0] as keyof ImageModel['proxied']] = generateUrl(acc[1]);
+      return pre;
+    },
+    {}
+  ),
+  livePhoto: image.livePhoto
+    ? {
+      ...image.livePhoto,
+      videoPath: generateUrl(image.livePhoto.videoPath),
+    }
+    : undefined,
+});

--- a/src/routes/api/v1/images/utils.ts
+++ b/src/routes/api/v1/images/utils.ts
@@ -61,13 +61,18 @@ export const composeWatermark = async (filePath: string) => {
     .toBuffer();
 };
 
-export const uploadImage = (path: string, key: string) => {
+export const uploadBuffer = (
+  buffer: Buffer,
+  key: string,
+  contentType?: string
+) => {
   return new Promise(async (resolve, reject) => {
     s3.putObject(
       {
         Bucket: process.env.IMAGES_BUCKET_NAME,
         Key: key,
-        Body: await readFile(path),
+        Body: buffer,
+        ContentType: contentType,
       },
       (err) => {
         if (err) {
@@ -79,6 +84,10 @@ export const uploadImage = (path: string, key: string) => {
       }
     );
   });
+};
+
+export const uploadImage = async (path: string, key: string) => {
+  return uploadBuffer(await readFile(path), key);
 };
 
 export const convertExposureTime = (time?: number) => {

--- a/src/typings/images.ts
+++ b/src/typings/images.ts
@@ -7,6 +7,11 @@ export interface ImageModel {
     '720p'?: string;
     '1080p'?: string;
   };
+  livePhoto?: {
+    videoPath: string;
+    mime: 'video/mp4' | 'video/quicktime';
+    presentationTimestampUs?: number;
+  };
   exif: {
     manufacturer?: string;
     model?: string;

--- a/tests/image-serialization.test.ts
+++ b/tests/image-serialization.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.CDN_PREFIX = 'https://cdn.example.com/';
+
+import { serializeImagePaths } from '../src/routes/api/v1/images/serializers.ts';
+
+test('processImageObj converts live photo video path to CDN URL', () => {
+  const image = serializeImagePaths({
+    id: 'image-id',
+    objectPath: 'images/photo.webp',
+    sha256: 'sha256',
+    proxied: {
+      '480p': 'images/photo_480p.webp',
+    },
+    livePhoto: {
+      videoPath: 'live-photos/image-id.mp4',
+      mime: 'video/mp4',
+      presentationTimestampUs: 123,
+    },
+    exif: {},
+  }, (path) => `https://cdn.example.com/${path}`);
+
+  assert.equal(image.objectPath, 'https://cdn.example.com/images/photo.webp');
+  assert.equal(
+    image.livePhoto?.videoPath,
+    'https://cdn.example.com/live-photos/image-id.mp4'
+  );
+});

--- a/tests/motion-photo.test.ts
+++ b/tests/motion-photo.test.ts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseMotionPhotoFromBuffer,
+} from '../src/routes/api/v1/images/motion-photo.ts';
+
+const encoder = new TextEncoder();
+
+const buildFile = (prefix: string, video: Buffer) => Buffer.concat([
+  encoder.encode(prefix),
+  video,
+]);
+
+test('returns null for a regular image without motion metadata', () => {
+  const result = parseMotionPhotoFromBuffer(
+    Buffer.from('plain jpeg bytes'),
+    'jpg'
+  );
+
+  assert.equal(result, null);
+});
+
+test('extracts video bytes from modern motion photo container metadata', () => {
+  const video = Buffer.from([0, 0, 0, 24, 102, 116, 121, 112, 109, 112, 52, 50]);
+  const xmp = `
+    <x:xmpmeta>
+      <Container:Directory>
+        <Container:Item Item:Semantic="Primary" Item:Mime="image/jpeg" Item:Length="0" />
+        <Container:Item Item:Semantic="MotionPhoto" Item:Mime="video/mp4" Item:Length="${video.length}" Item:Padding="0" />
+      </Container:Directory>
+      <GCamera:MotionPhotoPresentationTimestampUs>123456</GCamera:MotionPhotoPresentationTimestampUs>
+    </x:xmpmeta>`;
+  const result = parseMotionPhotoFromBuffer(buildFile(xmp, video), 'jpg');
+
+  assert.deepEqual(result?.videoBuffer, video);
+  assert.equal(result?.mime, 'video/mp4');
+  assert.equal(result?.extension, 'mp4');
+  assert.equal(result?.presentationTimestampUs, 123456);
+});
+
+test('extracts video bytes from legacy MicroVideoOffset metadata', () => {
+  const video = Buffer.from([0, 0, 0, 16, 102, 116, 121, 112, 113, 116]);
+  const xmp = `
+    <x:xmpmeta
+      GCamera:MicroVideo="1"
+      GCamera:MicroVideoOffset="${video.length}"
+      GCamera:MicroVideoPresentationTimestampUs="42" />`;
+  const result = parseMotionPhotoFromBuffer(buildFile(xmp, video), 'jpg');
+
+  assert.deepEqual(result?.videoBuffer, video);
+  assert.equal(result?.mime, 'video/mp4');
+  assert.equal(result?.extension, 'mp4');
+  assert.equal(result?.presentationTimestampUs, 42);
+});
+
+test('returns null when metadata points outside the file', () => {
+  const xmp = '<x:xmpmeta GCamera:MicroVideo="1" GCamera:MicroVideoOffset="9999" />';
+  const result = parseMotionPhotoFromBuffer(Buffer.from(xmp), 'jpg');
+
+  assert.equal(result, null);
+});


### PR DESCRIPTION
## Summary
- Detect Android-style single-file Motion Photo metadata in uploaded JPG/HEIC files.
- Extract embedded video bytes, upload them separately, and store image.livePhoto metadata.
- Serialize livePhoto video paths through the CDN and add parser/serialization tests.

## Test Plan
- node --test tests/motion-photo.test.ts tests/image-serialization.test.ts
- pnpm build

## Deployment Note
- Production/staging DB needs: ALTER TABLE images ADD COLUMN live_photo JSON NULL;